### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ A lightweight PHP wrapper for the [Eventbrite API v3](https://www.eventbrite.co.
 [![Latest Stable Version](https://poser.pugx.org/jamiehollern/eventbrite/v/stable)](https://packagist.org/packages/jamiehollern/eventbrite)
 [![License](https://poser.pugx.org/jamiehollern/eventbrite/license)](https://packagist.org/packages/jamiehollern/eventbrite)
 
+<div style="margin: 25px;">
+<a href="https://rapidapi.com/package/EventbriteAPI/functions?utm_source=EventbriteGitHub-PHPSDK&utm_medium=button&utm_content=Vendor_GitHub" style="
+    all: initial;
+    background-color: #498FE1;
+    border-width: 0;
+    border-radius: 5px;
+    padding: 10px 20px;
+    color: white;
+    font-family: 'Helvetica';
+    font-size: 12pt;
+    background-image: url(https://scdn.rapidapi.com/logo-small.png);
+    background-size: 25px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 10px;
+    padding-left: 44px;
+    cursor: pointer;">
+  Run now on <b>RapidAPI</b>
+</a>
+</div>
+
 # Requirements
 * PHP >= 5.5
 * cURL if you don't want any extra config (see the [Guzzle docs](http://docs.guzzlephp.org/en/latest/faq.html#does-guzzle-require-curl))


### PR DESCRIPTION
Hey! i've added a link to Eventbrite's functions page on RapidAPI. It'll allow devs to test the API before implementing the SDK. Let me know if this is helpful!